### PR TITLE
deps: bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/eladnava/mailgen#readme",
   "dependencies": {
-    "ejs": "^2.4.2",
-    "juice": "^2.0.0"
+    "ejs": "^2.5.8",
+    "juice": "^4.2.3"
   }
 }


### PR DESCRIPTION
This commit bumps the dependency versions of the relevant modules.  There aren't any tests, but I've manually generated the previews in the examples directory and it doesn't seem like anything broke.