### PR TITLE
Added option to disable signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ var email = {
 };
 ```
 
-To not display the signature at all, set the signature field to false:
+To not include the signature at all, set the signature field to false:
 
 ```js
 var email = {

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ To not include the signature at all, set the signature field to false:
 ```js
 var email = {
     body: {
-      signature: false;
+      signature: false,
     }
 };
 ```

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ require('fs').writeFileSync('preview.html', emailBody, 'utf8');
 
 // `emailBody` now contains the HTML body,
 // and `emailText` contains the textual version.
-// 
+//
 // It's up to you to send the e-mail.
 // Check out nodemailer to accomplish this:
 // https://nodemailer.com/
@@ -138,6 +138,16 @@ var email = {
     body: {
         greeting: 'Dear',
         signature: 'Sincerely'
+    }
+};
+```
+
+To not display the signature at all, set the signature field to false:
+
+```js
+var email = {
+    body: {
+      signature: false;
     }
 };
 ```

--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ Mailgen.prototype.parseParams = function (params) {
     body.greeting = body.greeting || 'Hi';
 
     // Only set signature if signature is not false
-    if (!(body.signature === false)) {
+    if (body.signature !== false) {
       body.signature = body.signature || 'Yours truly';
     }
 

--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ Mailgen.prototype.generatePlaintext = function (params) {
     // Definition of the <br /> tag as a regex pattern
     var breakTag = /(?:\<br\s*\/?\>)/g;
     var breakTagPattern = new RegExp(breakTag);
-    
+
     // Check the plaintext for html break tag, maintains backwards compatiblity
     if (breakTagPattern.test(this.cachedPlaintextTheme)) {
         // Strip all linebreaks from the rendered plaintext
@@ -125,7 +125,11 @@ Mailgen.prototype.parseParams = function (params) {
 
     // Support for custom greeting/signature (fallback to sensible defaults)
     body.greeting = body.greeting || 'Hi';
-    body.signature = body.signature || 'Yours truly';
+
+    // Only set signature if signature is not false
+    if (!(body.signature === false)) {
+      body.signature = body.signature || 'Yours truly';
+    }
 
     // Use `greeting` and `name` for title if not set
     if (!body.title) {

--- a/themes/cerberus/index.html
+++ b/themes/cerberus/index.html
@@ -362,13 +362,15 @@ if (locals.action) {
                                     <% } %>
                                 </td>
                             </tr>
-                            <tr>
-	                            <td style="text-align: center; padding: 0 40px 40px 40px; font-family: sans-serif; font-size: 15px; mso-height-rule: exactly; line-height: 20px; color: #555555;">
-	                                <%- signature %>,
-                                    <br />
-                                    <%- product.name %>
-                                </td>
-                            </tr>
+                            <% if (signature) { %>
+                              <tr>
+  	                            <td style="text-align: center; padding: 0 40px 40px 40px; font-family: sans-serif; font-size: 15px; mso-height-rule: exactly; line-height: 20px; color: #555555;">
+  	                                <%- signature %>,
+                                      <br />
+                                      <%- product.name %>
+                                  </td>
+                              </tr>
+                            <% } %>
                         </table>
                     </td>
                 </tr>

--- a/themes/cerberus/index.txt
+++ b/themes/cerberus/index.txt
@@ -17,7 +17,7 @@
         <%- item.charAt(0).toUpperCase() + item.slice(1) %>: <%- dictionary[item] %>
         <br />
     <% } -%>
-    
+
     <br />
 <% } %>
 
@@ -27,7 +27,7 @@
         <br />
         <%- actionItem.button.link %>
         <br />
-        
+
         <br />
     <% }) -%>
 <% } %>
@@ -37,13 +37,15 @@
         <%- outroItem %>
         <br />
     <% }) -%>
-    
+
     <br />
 <% } %>
 
-<%- signature %>,
-<br />
-<%- product.name %>
+<% if (signature) { %>
+  <%- signature %>,
+  <br />
+  <%- product.name %>
+<% } %>
 
 <br />
 <br />

--- a/themes/default/index.html
+++ b/themes/default/index.html
@@ -367,11 +367,13 @@ if (locals.action) {
                       <% }) -%>
                     <% } %>
 
-                    <p>
-                      <%- signature %>,
-                      <br>
-                      <%- product.name %>
-                    </p>
+                    <% if (signature) { %>
+                      <p>
+                        <%- signature %>,
+                        <br>
+                        <%- product.name %>
+                      </p>
+                    <% } %>
                   </td>
                 </tr>
               </table>

--- a/themes/default/index.txt
+++ b/themes/default/index.txt
@@ -17,7 +17,7 @@
         <%- item.charAt(0).toUpperCase() + item.slice(1) %>: <%- dictionary[item] %>
         <br />
     <% } -%>
-    
+
     <br />
 <% } %>
 
@@ -27,7 +27,7 @@
         <br />
         <%- actionItem.button.link %>
         <br />
-        
+
         <br />
     <% }) -%>
 <% } %>
@@ -37,13 +37,15 @@
         <%- outroItem %>
         <br />
     <% }) -%>
-    
+
     <br />
 <% } %>
 
-<%- signature %>,
-<br />
-<%- product.name %>
+<% if (signature) { %>
+  <%- signature %>,
+  <br />
+  <%- product.name %>
+<% } %>
 
 <br />
 <br />

--- a/themes/neopolitan/index.html
+++ b/themes/neopolitan/index.html
@@ -187,7 +187,7 @@ if (locals.action) {
                       <br />
                         <table style="margin: 0 auto;" cellpadding="0" cellspacing="0" width="70%">
                             <tr>
-                                <td style="padding: 0 15px;"> 
+                                <td style="padding: 0 15px;">
                                   <% if (locals.intro) { %>
                                     <% intro.forEach(function (introItem) { -%>
                                       <p><%- introItem %></p>
@@ -312,9 +312,12 @@ if (locals.action) {
                                 <% }) -%>
                               <% } %>
 
-                              <%- signature %>,
-                              <br>
-                              <%- product.name %>
+                              <% if (signature) { %>
+                                <%- signature %>,
+                                <br>
+                                <%- product.name %>
+                              <% } %>
+
                               <br><br>
                             </td>
                           </tr>

--- a/themes/neopolitan/index.txt
+++ b/themes/neopolitan/index.txt
@@ -17,7 +17,7 @@
         <%- item.charAt(0).toUpperCase() + item.slice(1) %>: <%- dictionary[item] %>
         <br />
     <% } -%>
-    
+
     <br />
 <% } %>
 
@@ -27,7 +27,7 @@
         <br />
         <%- actionItem.button.link %>
         <br />
-        
+
         <br />
     <% }) -%>
 <% } %>
@@ -37,13 +37,15 @@
         <%- outroItem %>
         <br />
     <% }) -%>
-    
+
     <br />
 <% } %>
 
-<%- signature %>,
-<br />
-<%- product.name %>
+<% if (signature) { %>
+  <%- signature %>,
+  <br />
+  <%- product.name %>
+<% } %>
 
 <br />
 <br />

--- a/themes/salted/index.txt
+++ b/themes/salted/index.txt
@@ -17,7 +17,7 @@
         <%- item.charAt(0).toUpperCase() + item.slice(1) %>: <%- dictionary[item] %>
         <br />
     <% } -%>
-    
+
     <br />
 <% } %>
 
@@ -27,7 +27,7 @@
         <br />
         <%- actionItem.button.link %>
         <br />
-        
+
         <br />
     <% }) -%>
 <% } %>
@@ -37,13 +37,15 @@
         <%- outroItem %>
         <br />
     <% }) -%>
-    
+
     <br />
 <% } %>
 
-<%- signature %>,
-<br />
-<%- product.name %>
+<% if (signature) { %>
+  <%- signature %>,
+  <br />
+  <%- product.name %>
+<% } %>
 
 <br />
 <br />


### PR DESCRIPTION
Hi, I am using your library and am very happy with the simplicity to quickly generate mails. 

However some of our automated mails should not contain signatures (for example password reset mails) so I added an option to disable the signatures. It gets disabled by explicitly setting the signature field to false like so:

`const mail = {
  body: {
    signature: false,
    ...
  }
}`

Everything else stays untouched, so you can still use the default signature or provide an override.

I also implemented this change in the 4 themes by checking if signature is defined and then conditionally adding it.

Hope you like this PR, cheers!