### PR TITLE
feat/logo height- add option to add dynamic logo height 

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,9 @@ function Mailgen(options) {
         throw new Error('Please provide the product name and link.');
     }
 
+    // Support for custom logo height (fallback to 50px)
+    this.product.logoHeight = this.product.logoHeight || '50px'
+    
     // Support for custom text direction (fallback to LTR)
     this.textDirection = options.textDirection || 'ltr';
 

--- a/index.js
+++ b/index.js
@@ -19,9 +19,6 @@ function Mailgen(options) {
         throw new Error('Please provide the product name and link.');
     }
 
-    // Support for custom logo height (fallback to 50px)
-    this.product.logoHeight = this.product.logoHeight || '50px'
-    
     // Support for custom text direction (fallback to LTR)
     this.textDirection = options.textDirection || 'ltr';
 

--- a/themes/cerberus/index.html
+++ b/themes/cerberus/index.html
@@ -99,6 +99,9 @@ if (locals.action) {
             text-decoration:underline;
         }
 
+        .email-logo {
+            max-height: 50px;
+        }
 
         /* What it does: Overrides styles added when Yahoo's auto-senses a link. */
         .yshortcuts a {
@@ -214,7 +217,11 @@ if (locals.action) {
 					<td class="branding" style="padding: 30px 0; text-align: center">
                         <a href="<%- product.link %>" target="_blank">
                             <% if (locals.product.logo) { %>
-                                <img src="<%- product.logo %>" style="height: <%- product.logoHeight %>;" alt="" />
+                                <% if (product.logoHeight) { %> 
+                                    <img src="<%- product.logo %>" style=" height: <%- product.logoHeight %>;" alt="" />
+                                  <% } else { %>
+                                    <img src="<%- product.logo %>" class="email-logo" alt="" />
+                                    <% } %>
                             <% } else { %>
                                 <%- product.name %>
                             <% } %>

--- a/themes/cerberus/index.html
+++ b/themes/cerberus/index.html
@@ -99,9 +99,6 @@ if (locals.action) {
             text-decoration:underline;
         }
 
-        .email-logo {
-            max-height: 50px;
-        }
 
         /* What it does: Overrides styles added when Yahoo's auto-senses a link. */
         .yshortcuts a {
@@ -217,7 +214,7 @@ if (locals.action) {
 					<td class="branding" style="padding: 30px 0; text-align: center">
                         <a href="<%- product.link %>" target="_blank">
                             <% if (locals.product.logo) { %>
-                                <img src="<%- product.logo %>" class="email-logo" alt="" />
+                                <img src="<%- product.logo %>" style="height: <%- product.logoHeight %>;" alt="" />
                             <% } else { %>
                                 <%- product.name %>
                             <% } %>

--- a/themes/cerberus/index.html
+++ b/themes/cerberus/index.html
@@ -217,7 +217,7 @@ if (locals.action) {
 					<td class="branding" style="padding: 30px 0; text-align: center">
                         <a href="<%- product.link %>" target="_blank">
                             <% if (locals.product.logo) { %>
-                                <% if (product.logoHeight) { %> 
+                                <% if (locals.product.logoHeight) { %> 
                                     <img src="<%- product.logo %>" style=" height: <%- product.logoHeight %>;" alt="" />
                                   <% } else { %>
                                     <img src="<%- product.logo %>" class="email-logo" alt="" />

--- a/themes/default/index.html
+++ b/themes/default/index.html
@@ -76,9 +76,7 @@ if (locals.action) {
       text-decoration: none;
       text-shadow: 0 1px 0 white;
     }
-    .email-logo {
-      max-height: 50px;
-    }
+  
 
     /* Body ------------------------------ */
     .email-body {
@@ -243,7 +241,7 @@ if (locals.action) {
             <td class="email-masthead">
               <a class="email-masthead_name" href="<%- product.link %>" target="_blank">
                 <% if (locals.product.logo) { %>
-                  <img src="<%- product.logo %>" class="email-logo" alt="" />
+                  <img src="<%- product.logo %>" style="height: <%- product.logoHeight %>;" alt="" />
                 <% } else { %>
                   <%- product.name %>
                 <% } %>

--- a/themes/default/index.html
+++ b/themes/default/index.html
@@ -76,7 +76,9 @@ if (locals.action) {
       text-decoration: none;
       text-shadow: 0 1px 0 white;
     }
-  
+    .email-logo {
+      max-height: 50px;
+    }
 
     /* Body ------------------------------ */
     .email-body {
@@ -241,7 +243,11 @@ if (locals.action) {
             <td class="email-masthead">
               <a class="email-masthead_name" href="<%- product.link %>" target="_blank">
                 <% if (locals.product.logo) { %>
-                  <img src="<%- product.logo %>" style="height: <%- product.logoHeight %>;" alt="" />
+                  <% if (product.logoHeight) { %> 
+                    <img src="<%- product.logo %>" style=" height: <%- product.logoHeight %>;" alt="" />
+                  <% } else { %>
+                    <img src="<%- product.logo %>" class="email-logo" alt="" />
+                    <% } %>
                 <% } else { %>
                   <%- product.name %>
                 <% } %>

--- a/themes/neopolitan/index.html
+++ b/themes/neopolitan/index.html
@@ -79,6 +79,10 @@ if (locals.action) {
     border-collapse: collapse !important;
   }
 
+  .email-logo {
+       max-height: 50px;
+  }
+
   .headline {
     color: #ffffff;
     font-size: 36px;
@@ -161,7 +165,11 @@ if (locals.action) {
                     <td class="branding" style="font-size: 30px; text-align:center;">
                         <a href="<%- product.link %>" target="_blank">
                             <% if (locals.product.logo) { %>
-                                <img src="<%- product.logo %>" style="height: <%- product.logoHeight %>;" alt="" />
+                              <% if (product.logoHeight) { %> 
+                                <img src="<%- product.logo %>" style=" height: <%- product.logoHeight %>;" alt="" />
+                              <% } else { %>
+                                <img src="<%- product.logo %>" class="email-logo" alt="" />
+                                <% } %>
                             <% } else { %>
                                 <%- product.name %>
                             <% } %>

--- a/themes/neopolitan/index.html
+++ b/themes/neopolitan/index.html
@@ -79,10 +79,6 @@ if (locals.action) {
     border-collapse: collapse !important;
   }
 
-  .email-logo {
-       max-height: 50px;
-  }
-
   .headline {
     color: #ffffff;
     font-size: 36px;
@@ -165,7 +161,7 @@ if (locals.action) {
                     <td class="branding" style="font-size: 30px; text-align:center;">
                         <a href="<%- product.link %>" target="_blank">
                             <% if (locals.product.logo) { %>
-                                <img src="<%- product.logo %>" class="email-logo" alt="" />
+                                <img src="<%- product.logo %>" style="height: <%- product.logoHeight %>;" alt="" />
                             <% } else { %>
                                 <%- product.name %>
                             <% } %>

--- a/themes/salted/index.html
+++ b/themes/salted/index.html
@@ -215,7 +215,7 @@ if (locals.action) {
                                                     <span class="branding" style="color: #666666; text-decoration: none;">
                                                         <a href="<%- product.link %>" target="_blank">
                                                             <% if (locals.product.logo) { %>
-                                                                <% if (product.logoHeight) { %> 
+                                                                <% if (locals.product.logoHeight) { %> 
                                                                     <img src="<%- product.logo %>" style=" height: <%- product.logoHeight %>;" alt="" />
                                                                   <% } else { %>
                                                                     <img src="<%- product.logo %>" class="email-logo" alt="" />

--- a/themes/salted/index.html
+++ b/themes/salted/index.html
@@ -54,6 +54,10 @@ if (locals.action) {
       margin: 0 auto;
     }
 
+    .email-logo {
+      max-height: 50px;
+    }
+
     .branding a {
         color: inherit;
         text-decoration: none;
@@ -211,7 +215,11 @@ if (locals.action) {
                                                     <span class="branding" style="color: #666666; text-decoration: none;">
                                                         <a href="<%- product.link %>" target="_blank">
                                                             <% if (locals.product.logo) { %>
-                                                                <img src="<%- product.logo %>" style="height: <%- product.logoHeight %>;" alt="" />
+                                                                <% if (product.logoHeight) { %> 
+                                                                    <img src="<%- product.logo %>" style=" height: <%- product.logoHeight %>;" alt="" />
+                                                                  <% } else { %>
+                                                                    <img src="<%- product.logo %>" class="email-logo" alt="" />
+                                                                    <% } %>
                                                             <% } else { %>
                                                                 <%- product.name %>
                                                             <% } %>

--- a/themes/salted/index.html
+++ b/themes/salted/index.html
@@ -54,10 +54,6 @@ if (locals.action) {
       margin: 0 auto;
     }
 
-    .email-logo {
-      max-height: 50px;
-    }
-
     .branding a {
         color: inherit;
         text-decoration: none;
@@ -215,7 +211,7 @@ if (locals.action) {
                                                     <span class="branding" style="color: #666666; text-decoration: none;">
                                                         <a href="<%- product.link %>" target="_blank">
                                                             <% if (locals.product.logo) { %>
-                                                                <img src="<%- product.logo %>" class="email-logo" alt="" />
+                                                                <img src="<%- product.logo %>" style="height: <%- product.logoHeight %>;" alt="" />
                                                             <% } else { %>
                                                                 <%- product.name %>
                                                             <% } %>


### PR DESCRIPTION
This PR adds the option to set a logo height in the email header 
A custom logo height can be added to the product object: 
```
product: {
   ...
   logo: './twitter.png',
   logoHeight: '87px'
}
```
with 87px being the wanted logo size.