### PR TITLE
Remove copyright from all themes plaintext

### DIFF
--- a/themes/cerberus/index.txt
+++ b/themes/cerberus/index.txt
@@ -46,7 +46,3 @@
   <br />
   <%- product.name %>
 <% } %>
-
-<br />
-<br />
-<%- product.copyright %>

--- a/themes/default/index.txt
+++ b/themes/default/index.txt
@@ -46,7 +46,3 @@
   <br />
   <%- product.name %>
 <% } %>
-
-<br />
-<br />
-<%- product.copyright %>

--- a/themes/neopolitan/index.txt
+++ b/themes/neopolitan/index.txt
@@ -46,7 +46,3 @@
   <br />
   <%- product.name %>
 <% } %>
-
-<br />
-<br />
-<%- product.copyright %>

--- a/themes/salted/index.txt
+++ b/themes/salted/index.txt
@@ -46,7 +46,3 @@
   <br />
   <%- product.name %>
 <% } %>
-
-<br />
-<br />
-<%- product.copyright %>


### PR DESCRIPTION
Kind of fixes #23. In my opinion we don't need to show copyright on plaintext at all.