### PR TITLE
fix(typings): added textDirection option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,11 @@ declare namespace Mailgen {
     interface Option {
         theme: string | CustomTheme;
         product: Product;
+        /**
+         * To change the default text direction
+         * @default ltr
+         */
+        textDirection?: 'ltr' | 'rtl' | string;
     }
 
     interface CustomTheme {


### PR DESCRIPTION
Hey there,
According to the [doc](https://github.com/eladnava/mailgen#rtl-support) and the [source code](https://github.com/eladnava/mailgen/blob/master/index.js#L24), constructor option accepts the `textDirection` field,
And I couldn't initiate the Mailgen instance using TypeScript because the `textDirection` option _was missing_.

For backward compatibility,
I made the option entirely and added the `string` to the types.
It does not break the current API and does not introduce any breaking change.