### PR TITLE
feat: add multiple buttons per action

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,6 +156,11 @@ Mailgen.prototype.parseParams = function (params) {
     body.intro = convertToArray(body.intro);
     body.outro = convertToArray(body.outro);
     body.action = convertToArray(body.action);
+    
+    // Enable multiple buttons per action
+    for (var a of body.action) {
+        a.button = convertToArray(a.button);
+    }
     body.table = convertToArray(body.table);
 
     // Prepare data to be passed to ejs engine

--- a/themes/cerberus/index.html
+++ b/themes/cerberus/index.html
@@ -336,11 +336,13 @@ if (locals.action) {
                                                 <![if !mso]>
                                                     <table cellspacing="0" cellpadding="0" border="0" align="center" style="margin: auto;">
                                                         <tr>
-                                                            <td style="background-color: <%- actionItem.button.color %>;" class="button-td">
-                                                                <a href="<%- actionItem.button.link %>" target="_blank" style="background-color: <%- actionItem.button.color %>; border-color: <%- actionItem.button.color %>;" class="button-a">
-                                                                    &nbsp;&nbsp;&nbsp;&nbsp;<span style="color:#ffffff"><%- actionItem.button.text %></span>&nbsp;&nbsp;&nbsp;&nbsp;
-                                                                </a>
-                                                            </td>
+                                                            <% actionItem.button.forEach(function (actionButton) { -%>
+                                                                <td style="background-color: <%- actionItem.button.color %>;" class="button-td">
+                                                                  <a href="<%- actionButton.link %>" target="_blank" style="background-color: <%- actionButton.color %>; border-color: <%- actionButton.color %>;" class="button-a">
+                                                                    &nbsp;&nbsp;&nbsp;&nbsp;<span style="color:#ffffff"><%- actionButton.text %></span>&nbsp;&nbsp;&nbsp;&nbsp;
+                                                                  </a>
+                                                                </td>
+                                                            <% }) -%>
                                                         </tr>
                                                     </table>
                                                 <![endif]>

--- a/themes/cerberus/index.txt
+++ b/themes/cerberus/index.txt
@@ -27,8 +27,10 @@
     <% action.forEach(function (actionItem) { -%>
         <%- actionItem.instructions %>
         <br />
-        <%- actionItem.button.link %>
-        <br />
+        <% actionItem.button.forEach(function (actionButton) { -%>
+            <%- actionButton.link %>
+            <br />
+        <% }) -%>
 
         <br />
     <% }) -%>

--- a/themes/default/index.html
+++ b/themes/default/index.html
@@ -339,11 +339,13 @@ if (locals.action) {
                         <![if !mso]>
                           <table class="body-action" align="center" cellpadding="0" cellspacing="0">
                             <tr>
-                              <td align="center">
-                                <a href="<%- actionItem.button.link %>" class="button" target="_blank" style="background-color: <%- actionItem.button.color %>;">
-                                  <%- actionItem.button.text %>
-                                </a>
-                              </td>
+                              <% actionItem.button.forEach(function (actionButton) { -%>
+                                <td align="center">
+                                  <a href="<%- actionButton.link %>" class="button" target="_blank" style="background-color: <%- actionButton.color %>;">
+                                    <%- actionButton.text %>
+                                  </a>
+                                </td>
+                              <% }) -%>
                             </tr>
                           </table>
                         <![endif]>

--- a/themes/default/index.txt
+++ b/themes/default/index.txt
@@ -27,8 +27,10 @@
     <% action.forEach(function (actionItem) { -%>
         <%- actionItem.instructions %>
         <br />
-        <%- actionItem.button.link %>
-        <br />
+        <% actionItem.button.forEach(function (actionButton) { -%>
+            <%- actionButton.link %>
+            <br />
+        <% }) -%>
 
         <br />
     <% }) -%>

--- a/themes/neopolitan/index.html
+++ b/themes/neopolitan/index.html
@@ -292,19 +292,22 @@ if (locals.action) {
                                 </tr>
                                 <tr>
                                     <td style="padding: 0 15px;">
-                                    <div><!--[if mso]>
-                                        <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="http://" style="height:50px;v-text-anchor:middle;width:200px;" arcsize="8%" stroke="f" fillcolor="#178f8f">
-                                        <w:anchorlock/>
-                                        <center>
-                                        <![endif]-->
-                                            <a target="_blank" href="<%- actionItem.button.link %>"
-                                    style="background-color:<%- actionItem.button.color %>;border-radius:4px;color:#ffffff;display:inline-block;font-family:Helvetica, Arial, sans-serif;font-size:16px;font-weight:bold;line-height:50px;text-align:center;text-decoration:none;width:200px;-webkit-text-size-adjust:none;">
-                                    <%- actionItem.button.text %>
-                                    </a>
+                                    <% actionItem.button.forEach(function (actionButton) { -%>
+                                      <div>
                                         <!--[if mso]>
-                                        </center>
-                                        </v:roundrect>
-                                    <![endif]--></div>
+                                          <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="http://" style="height:50px;v-text-anchor:middle;width:200px;" arcsize="8%" stroke="f" fillcolor="#178f8f">
+                                          <w:anchorlock/>
+                                          <center>
+                                        <![endif]-->
+                                        <a target="_blank" href="<%- actionButton.link %>" style="background-color:<%- actionButton.color %>;border-radius:4px;color:#ffffff;display:inline-block;font-family:Helvetica, Arial, sans-serif;font-size:16px;font-weight:bold;line-height:50px;text-align:center;text-decoration:none;width:200px;-webkit-text-size-adjust:none;">
+                                          <%- actionButton.text %>
+                                        </a>
+                                        <!--[if mso]>
+                                          </center>
+                                          </v:roundrect>
+                                        <![endif]-->
+                                      </div>
+                                    <% }) -%>
                                 <% }) -%>
                             <% } %>
                                 <br>

--- a/themes/neopolitan/index.txt
+++ b/themes/neopolitan/index.txt
@@ -27,8 +27,10 @@
     <% action.forEach(function (actionItem) { -%>
         <%- actionItem.instructions %>
         <br />
-        <%- actionItem.button.link %>
-        <br />
+        <% actionItem.button.forEach(function (actionButton) { -%>
+            <%- actionButton.link %>
+            <br />
+        <% }) -%>
 
         <br />
     <% }) -%>

--- a/themes/salted/index.html
+++ b/themes/salted/index.html
@@ -359,7 +359,9 @@ if (locals.action) {
                                                     <td align="center" style="padding: 25px 0 0 0;" class="padding-copy">
                                                         <table border="0" cellspacing="0" cellpadding="0" class="responsive-table">
                                                             <tr>
-                                                                <td align="center"><a href="<%- actionItem.button.link %>" target="_blank" style="font-size: 16px; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-weight: normal; color: #ffffff; text-decoration: none; background-color: <%- actionItem.button.color %>; border-top: 15px solid <%- actionItem.button.color %>; border-bottom: 15px solid <%- actionItem.button.color %>; border-left: 25px solid <%- actionItem.button.color %>; border-right: 25px solid <%- actionItem.button.color %>; border-radius: 3px; -webkit-border-radius: 3px; -moz-border-radius: 3px; display: inline-block;" class="mobile-button"><%- actionItem.button.text %> &rarr;</a></td>
+                                                                <% actionItem.button.forEach(function (actionButton) { -%>
+                                                                    <td align="center"><a href="<%- actionButton.link %>" target="_blank" style="font-size: 16px; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-weight: normal; color: #ffffff; text-decoration: none; background-color: <%- actionButton.color %>; border-top: 15px solid <%- actionButton.color %>; border-bottom: 15px solid <%- actionButton.color %>; border-left: 25px solid <%- actionButton.color %>; border-right: 25px solid <%- actionButton.color %>; border-radius: 3px; -webkit-border-radius: 3px; -moz-border-radius: 3px; display: inline-block;" class="mobile-button"><%- actionButton.text %> &rarr;</a></td>
+                                                                <% }) -%>
                                                             </tr>
                                                         </table>
                                                     </td>

--- a/themes/salted/index.txt
+++ b/themes/salted/index.txt
@@ -27,8 +27,10 @@
     <% action.forEach(function (actionItem) { -%>
         <%- actionItem.instructions %>
         <br />
-        <%- actionItem.button.link %>
-        <br />
+        <% actionItem.button.forEach(function (actionButton) { -%>
+            <%- actionButton.link %>
+            <br />
+        <% }) -%>
 
         <br />
     <% }) -%>


### PR DESCRIPTION
I added the possibility to insert multiple button object for any action.
E.g.
```
action: [{
  instructions,
  button: [
    { color, text, link },
    { color, text, link }
  ],
}],
```
It is still possible to use the button prop as an object.
I have also updated all the themes in order to handle the button of each action as an array.