### PR TITLE
fix: convertToArray handle undefined cases

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,13 +30,8 @@ function Mailgen(options) {
     this.cacheThemes();
 }
 
-function convertToArray(data) {
-    // Convert object to array
-    if (data && data.constructor !== Array) {
-        return [data];
-    }
-
-    return data;
+function convertToArray (arr) {
+  return Array.isArray(arr) ? arr : [arr].filter(Boolean)
 }
 
 Mailgen.prototype.cacheThemes = function () {


### PR DESCRIPTION
This bug was introduced in the version 2.0.21.

Since loops are expecting an array to iterate, it throws an error when you try to iterate `undefined`

The change just ensure undefined or any other nully value is treated properly

`convertToArray(undefined)  → []`