### PR TITLE
feat(typings): improve TS typing of column options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -64,8 +64,8 @@ declare namespace Mailgen {
     }
 
     interface ColumnOptions {
-        customWidth: any;
-        customAlignment: any;
+        customWidth?: Record<string, string>;
+        customAlignment?: Record<string, string>;
     }
 
     interface GoToAction {


### PR DESCRIPTION
Hey hey,

According to the [docs](https://github.com/eladnava/mailgen#table) and our usage of the package, `customWidth` and `customAlignment` are optional, but declared as required in the TS typings.