### PR TITLE
Add title to Table type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -59,6 +59,7 @@ declare namespace Mailgen {
     }
 
     interface Table {
+        title?: string,
         data: any[];
         columns?: ColumnOptions;
     }


### PR DESCRIPTION
In the doc, it is stated that you can add a title to a table object.
Unfortunately, the typing for Table did not seem to agree before :c